### PR TITLE
fix(build): disable jar creation for authorization server

### DIFF
--- a/Chapter11/spring-cloud/authorization-server/build.gradle
+++ b/Chapter11/spring-cloud/authorization-server/build.gradle
@@ -16,6 +16,10 @@ ext {
     springCloudVersion = "2022.0.1"
 }
 
+jar {
+    enabled = false
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'


### PR DESCRIPTION
I just tried to build Chapter11 and faced this issue:
```
Step 3/12 : ADD ./build/libs/*.jar app.jar
When using ADD with more than one source file, the destination must be a directory and end with a /
ERROR: Service 'auth-server' failed to build : Build failed
➜  Chapter11 git:(main) ✗ ll spring-cloud/authorization-server/build/libs
total 47M
-rw-rw-r-- 1 a506486 a506486 47M Dec 15 15:15 authorization-server-1.0.0-SNAPSHOT.jar
-rw-rw-r-- 1 a506486 a506486 12K Dec 15 15:15 authorization-server-1.0.0-SNAPSHOT-plain.jar
➜  Chapter11 git:(fix/chapter-11) ✗
```
This PR should fix that.